### PR TITLE
WebChucK on Safari Fix

### DIFF
--- a/ide/js/webchuck_host.js
+++ b/ide/js/webchuck_host.js
@@ -90,6 +90,7 @@ var startAudioContext = async function()
     audioContext = new AudioContext({
         //sampleRate: 48000
     });
+    await audioContext.resume();
     await audioContext.audioWorklet.addModule( whereIsChuck + '/webchuck.js');
 }
 

--- a/src/webchuck_host.js
+++ b/src/webchuck_host.js
@@ -103,6 +103,7 @@ var startAudioContext = async function()
     audioContext = new AudioContext({
         //sampleRate: 48000
     });
+    await audioContext.resume();
     await audioContext.audioWorklet.addModule( whereIsChuck + '/webchuck.js');
 }
 


### PR DESCRIPTION
Added AudioContext.resume() call after user interaction (in startAudioContext() in webchuck_host.js), after parsing this overflow post: 

https://stackoverflow.com/questions/73164697/implementing-an-audioworklet-in-safari