### PR TITLE
Better TypeScript returns type for promises

### DIFF
--- a/dist/Chuck.d.ts
+++ b/dist/Chuck.d.ts
@@ -78,7 +78,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * theChuck.loadFile("./myFile.ck");
      * ```
      * @param url path or url to a file to fetch and load file
-     * @returns promise of fetch request
+     * @returns Promise of fetch request
      */
     loadFile(url: string): Promise<void>;
     /**
@@ -251,7 +251,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the value of a global int variable in ChucK.
      * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
      * @param variable Name of int global variable
-     * @returns promise with int value of the variable
+     * @returns Promise with int value of the variable
      */
     getInt(variable: string): Promise<number>;
     /**
@@ -263,7 +263,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global float variable in ChucK.
      * @param variable Name of float global variable
-     * @returns promise with float value of the variable
+     * @returns Promise with float value of the variable
      */
     getFloat(variable: string): Promise<number>;
     /**
@@ -275,7 +275,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global string variable in ChucK.
      * @param variable Name of string global variable
-     * @returns promise with string value of the variable
+     * @returns Promise with string value of the variable
      */
     getString(variable: string): Promise<string>;
     /**
@@ -318,7 +318,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative int arry
      * @param key The key index (string) to get
-     * @returns promise with int array value
+     * @returns Promise with int array value
      */
     getAssociativeIntArrayValue(variable: string, key: string): Promise<number>;
     /**
@@ -331,7 +331,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the values of a global float array in ChucK.
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
      * @param variable Name of float array
-     * @returns promise of float values
+     * @returns Promise of float values
      */
     getFloatArray(variable: string): Promise<number[]>;
     /**
@@ -346,7 +346,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
      * @param variable Name of global float array
      * @param index Index of element
-     * @returns promise of float value at index
+     * @returns Promise of float value at index
      */
     getFloatArrayValue(variable: string, index: number): Promise<number>;
     /**
@@ -363,7 +363,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative float array
      * @param key The key index (string) to get
-     * @returns promise with float array value
+     * @returns Promise with float array value
      */
     getAssociativeFloatArrayValue(variable: string, key: string): Promise<number>;
     /**
@@ -377,7 +377,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM integer parameter.
      * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
      * @param name Name of VM int parameter to get
-     * @returns promise with int value
+     * @returns Promise with int value
      */
     getParamInt(name: string): Promise<number>;
     /**
@@ -389,7 +389,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get an internal ChucK VM float parameter.
      * @param name Name of VM float parameter to get
-     * @returns promise with float value
+     * @returns Promise with float value
      */
     getParamFloat(name: string): Promise<number>;
     /**
@@ -402,7 +402,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM string parameter.
      * e.g. "VERSION".
      * @param name Name of VM string parameter to get
-     * @returns promise with string value
+     * @returns Promise with string value
      */
     getParamString(name: string): Promise<string>;
     /**

--- a/dist/Chuck.d.ts
+++ b/dist/Chuck.d.ts
@@ -58,7 +58,7 @@ export default class Chuck extends window.AudioWorkletNode {
     static init(filenamesToPreload: Filename[], audioContext?: AudioContext, numOutChannels?: number, whereIsChuck?: string): Promise<Chuck>;
     /**
      * Private function for ChucK to handle execution of tasks.
-     * Will create a Deferred Promise that wraps a task for WebChucK to execute
+     * Will create a Deferred promise that wraps a task for WebChucK to execute
      * @returns callbackID to a an action for ChucK to perform
      */
     private nextDeferID;
@@ -78,44 +78,45 @@ export default class Chuck extends window.AudioWorkletNode {
      * theChuck.loadFile("./myFile.ck");
      * ```
      * @param url path or url to a file to fetch and load file
+     * @returns promise of fetch request
      */
     loadFile(url: string): Promise<void>;
     /**
      * Run a string of ChucK code.
      * @example theChuck.runCode("SinOsc osc => dac; 1::second => now;");
      * @param code ChucK code string to be executed
-     * @returns Promise to the shred ID
+     * @returns Promise to shred ID
      */
-    runCode(code: string): Promise<unknown>;
+    runCode(code: string): Promise<number>;
     /**
      * @hidden
      * Run a string of ChucK code using a different dac (unsure of functionality)
      * -tf (5/30/2023)
      * @param code ChucK code string to be executed
      * @param dacName dac for ChucK (??)
-     * @returns promise to the shred ID
+     * @returns Promise to shred ID
      */
-    runCodeWithReplacementDac(code: string, dacName: string): Promise<unknown>;
+    runCodeWithReplacementDac(code: string, dacName: string): Promise<number>;
     /**
      * Replace the last currently running shred with string of ChucK code to execute.
      * @example theChuck.replaceCode("SinOsc osc => dac; 1::second => now;");
      * @param code ChucK code string to run and replace last shred
      * @returns Promise to shred ID that is replaced
      */
-    replaceCode(code: string): Promise<unknown>;
+    replaceCode(code: string): Promise<number>;
     /**
      * @hidden
      * Replace last running shred with string of ChucK code to execute, to another dac (??)
      * @param code ChucK code string to replace last Shred
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
-    replaceCodeWithReplacementDac(code: string, dacName: string): Promise<unknown>;
+    replaceCodeWithReplacementDac(code: string, dacName: string): Promise<number>;
     /**
      * Remove the last running shred from Chuck Virtual Machine.
-     * @returns promise to the shred ID that was removed
+     * @returns Promise to the shred ID that was removed
      */
-    removeLastCode(): Promise<unknown>;
+    removeLastCode(): Promise<number>;
     /**
      * Run a ChucK file that is already loaded in the WebChucK virtual file system.
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
@@ -129,16 +130,16 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param filename ChucK file to be run
      * @returns Promise to running shred ID
      */
-    runFile(filename: string): Promise<unknown>;
+    runFile(filename: string): Promise<number>;
     /**
      * @hidden
      * Run a ChucK file that is already in the WebChucK virtual file system, on separate dac (??).
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename ChucK file to be run
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
-    runFileWithReplacementDac(filename: string, dacName: string): Promise<unknown>;
+    runFileWithReplacementDac(filename: string, dacName: string): Promise<number>;
     /**
      * Run a ChucK file already loaded in the WebChucK virtual file system and pass in arguments.
      * e.g. Thie is the chuck command line equivalent of `chuck myFile:1:2:foo`
@@ -147,7 +148,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param colonSeparatedArgs arguments to pass to the file separated by colons
      * @returns Promise to running shred ID
      */
-    runFileWithArgs(filename: string, colonSeparatedArgs: string): Promise<unknown>;
+    runFileWithArgs(filename: string, colonSeparatedArgs: string): Promise<number>;
     /**
      * @hidden
      * Run a ChucK file that is already in the WebChucK virtual file system with arguments.
@@ -155,33 +156,33 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param filename ChucK file to be run
      * @param colonSeparatedArgs arguments to pass to the file
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
-    runFileWithArgsWithReplacementDac(filename: string, colonSeparatedArgs: string, dacName: string): Promise<unknown>;
+    runFileWithArgsWithReplacementDac(filename: string, colonSeparatedArgs: string, dacName: string): Promise<number>;
     /**
      * Replace the last currently running shred with a Chuck file to execute.
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename file to be replace last
      * @returns Promise to replaced shred ID
      */
-    replaceFile(filename: string): Promise<unknown>;
+    replaceFile(filename: string): Promise<number>;
     /**
      * @hidden
      * Replace the last running shred with a file to execute.
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename file to be replace last
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
-    replaceFileWithReplacementDac(filename: string, dacName: string): Promise<unknown>;
+    replaceFileWithReplacementDac(filename: string, dacName: string): Promise<number>;
     /**
      * Replace the last running shred with a file to execute, passing arguments.
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename file to be replace last running shred
      * @param colonSeparatedArgs arguments to pass in to file
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
-    replaceFileWithArgs(filename: string, colonSeparatedArgs: string): Promise<unknown>;
+    replaceFileWithArgs(filename: string, colonSeparatedArgs: string): Promise<number>;
     /**
      * @hidden
      * Replace the last running shred with a file to execute, passing arguments, and dac.
@@ -189,21 +190,21 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param filename file to be replace last running shred
      * @param colonSeparatedArgs arguments to pass in to file
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
-    replaceFileWithArgsWithReplacementDac(filename: string, colonSeparatedArgs: string, dacName: string): Promise<unknown>;
+    replaceFileWithArgsWithReplacementDac(filename: string, colonSeparatedArgs: string, dacName: string): Promise<number>;
     /**
      * Remove a shred from ChucK VM by ID
      * @param shred shred ID to be removed
      * @returns Promise to shred ID if removed successfully, otherwise "removing code failed"
      */
-    removeShred(shred: number | string): Promise<unknown>;
+    removeShred(shred: number | string): Promise<number>;
     /**
      * Check if shred with ID is running in the Chuck Virtual Machine.
      * @param shred The shred ID to check
      * @returns Promise to whether shred is running, 1 if running, 0 if not
      */
-    isShredActive(shred: number | string): Promise<unknown>;
+    isShredActive(shred: number | string): Promise<number>;
     /**
      * Signal a ChucK event global. This will wake the first waiting Shred.
      * @param variable ChucK global event variable to be signaled
@@ -250,9 +251,9 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the value of a global int variable in ChucK.
      * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
      * @param variable Name of int global variable
-     * @returns Promise with int value of the variable
+     * @returns promise with int value of the variable
      */
-    getInt(variable: string): Promise<unknown>;
+    getInt(variable: string): Promise<number>;
     /**
      * Set the value of a global float variable in ChucK.
      * @param variable Name of float global variable
@@ -262,9 +263,9 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global float variable in ChucK.
      * @param variable Name of float global variable
-     * @returns Promise with float value of the variable
+     * @returns promise with float value of the variable
      */
-    getFloat(variable: string): Promise<unknown>;
+    getFloat(variable: string): Promise<number>;
     /**
      * Set the value of a global string variable in ChucK.
      * @param variable Name of string global variable
@@ -274,9 +275,9 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global string variable in ChucK.
      * @param variable Name of string global variable
-     * @returns Promise with string value of the variable
+     * @returns promise with string value of the variable
      */
-    getString(variable: string): Promise<unknown>;
+    getString(variable: string): Promise<string>;
     /**
      * Set the values of a global int array in ChucK.
      * @param variable Name of global int array variable
@@ -288,7 +289,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param variable Name of global int array variable
      * @returns Promise to array of numbers
      */
-    getIntArray(variable: string): Promise<unknown>;
+    getIntArray(variable: string): Promise<number[]>;
     /**
      * Set a single value (by index) in a global int array in ChucK.
      * @param variable Name of int array variable
@@ -302,7 +303,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param index Array index to get
      * @returns Promise to the value at the index
      */
-    getIntArrayValue(variable: string, index: number): Promise<unknown>;
+    getIntArrayValue(variable: string, index: number): Promise<number>;
     /**
      * Set the value (by key) of an associative int array in ChucK.
      * Note that "associative array" is ChucK's version of a dictionary with string keys mapping to values (see ChucK documentation).
@@ -317,9 +318,9 @@ export default class Chuck extends window.AudioWorkletNode {
      * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative int arry
      * @param key The key index (string) to get
-     * @returns Promise with int array value
+     * @returns promise with int array value
      */
-    getAssociativeIntArrayValue(variable: string, key: string): Promise<unknown>;
+    getAssociativeIntArrayValue(variable: string, key: string): Promise<number>;
     /**
      * Set the values of a global float array in ChucK.
      * @param variable Name of global float array
@@ -330,9 +331,9 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the values of a global float array in ChucK.
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
      * @param variable Name of float array
-     * @returns Promise of float values
+     * @returns promise of float values
      */
-    getFloatArray(variable: string): Promise<unknown>;
+    getFloatArray(variable: string): Promise<number[]>;
     /**
      * Set the float value of a global float array at particular index.
      * @param variable Name of global float array
@@ -345,9 +346,9 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
      * @param variable Name of global float array
      * @param index Index of element
-     * @returns Promise of float value at index
+     * @returns promise of float value at index
      */
-    getFloatArrayValue(variable: string, index: number): Promise<unknown>;
+    getFloatArrayValue(variable: string, index: number): Promise<number>;
     /**
      * Set the value (by key) of an associative float array in ChucK.
      * Note that "associative array" is ChucK's version of a dictionary with string keys mapping to values (see ChucK documentation).
@@ -362,9 +363,9 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative float array
      * @param key The key index (string) to get
-     * @returns Promise with float array value
+     * @returns promise with float array value
      */
-    getAssociativeFloatArrayValue(variable: string, key: string): Promise<unknown>;
+    getAssociativeFloatArrayValue(variable: string, key: string): Promise<number>;
     /**
      * Set an internal ChucK VM integer parameter.
      * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "IS_REAL_TIME_AUDIO_HINT", "TTY_COLOR".
@@ -376,9 +377,9 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM integer parameter.
      * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
      * @param name Name of VM int parameter to get
-     * @returns Promise with int value
+     * @returns promise with int value
      */
-    getParamInt(name: string): Promise<unknown>;
+    getParamInt(name: string): Promise<number>;
     /**
      * Set an internal ChucK VM float parameter.
      * @param name Name of VM float parameter to set
@@ -388,9 +389,9 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get an internal ChucK VM float parameter.
      * @param name Name of VM float parameter to get
-     * @returns Promise with float value
+     * @returns promise with float value
      */
-    getParamFloat(name: string): Promise<unknown>;
+    getParamFloat(name: string): Promise<number>;
     /**
      * Set an internal ChucK VM string parameter.
      * @param name Name of VM string parameter to set
@@ -401,14 +402,14 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM string parameter.
      * e.g. "VERSION".
      * @param name Name of VM string parameter to get
-     * @returns Promise with string value
+     * @returns promise with string value
      */
-    getParamString(name: string): Promise<unknown>;
+    getParamString(name: string): Promise<string>;
     /**
      * Get the current time in samples of the ChucK VM.
      * @returns Promise to current sample time in ChucK (int)
      */
-    now(): Promise<unknown>;
+    now(): Promise<number>;
     /**
      * Remove all shreds and reset the ChucK instance.
      */

--- a/dist/Chuck.js
+++ b/dist/Chuck.js
@@ -110,7 +110,7 @@ export default class Chuck extends window.AudioWorkletNode {
     }
     /**
      * Private function for ChucK to handle execution of tasks.
-     * Will create a Deferred Promise that wraps a task for WebChucK to execute
+     * Will create a Deferred promise that wraps a task for WebChucK to execute
      * @returns callbackID to a an action for ChucK to perform
      */
     nextDeferID() {
@@ -141,26 +141,25 @@ export default class Chuck extends window.AudioWorkletNode {
      * theChuck.loadFile("./myFile.ck");
      * ```
      * @param url path or url to a file to fetch and load file
+     * @returns promise of fetch request
      */
     async loadFile(url) {
         const filename = url.split("/").pop();
-        if (url.endsWith(".ck")) {
-            return fetch(url).then((response) => response.text()).then((text) => {
-                this.createFile("", filename, text);
-            });
-        }
-        else {
-            return fetch(url).then((response) => response.arrayBuffer()).then((buffer) => {
-                this.createFile("", filename, new Uint8Array(buffer));
-            });
-        }
+        return fetch(url)
+            .then((response) => response.arrayBuffer())
+            .then((buffer) => {
+            this.createFile("", filename, new Uint8Array(buffer));
+        })
+            .catch((err) => {
+            throw new Error(err);
+        });
     }
     // ================== Run/Replace Code ================== //
     /**
      * Run a string of ChucK code.
      * @example theChuck.runCode("SinOsc osc => dac; 1::second => now;");
      * @param code ChucK code string to be executed
-     * @returns Promise to the shred ID
+     * @returns Promise to shred ID
      */
     runCode(code) {
         const callbackID = this.nextDeferID();
@@ -173,7 +172,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * -tf (5/30/2023)
      * @param code ChucK code string to be executed
      * @param dacName dac for ChucK (??)
-     * @returns promise to the shred ID
+     * @returns Promise to shred ID
      */
     runCodeWithReplacementDac(code, dacName) {
         const callbackID = this.nextDeferID();
@@ -203,7 +202,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Replace last running shred with string of ChucK code to execute, to another dac (??)
      * @param code ChucK code string to replace last Shred
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceCodeWithReplacementDac(code, dacName) {
         const callbackID = this.nextDeferID();
@@ -216,7 +215,7 @@ export default class Chuck extends window.AudioWorkletNode {
     }
     /**
      * Remove the last running shred from Chuck Virtual Machine.
-     * @returns promise to the shred ID that was removed
+     * @returns Promise to the shred ID that was removed
      */
     removeLastCode() {
         const callbackID = this.nextDeferID();
@@ -251,7 +250,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename ChucK file to be run
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     runFileWithReplacementDac(filename, dacName) {
         const callbackID = this.nextDeferID();
@@ -286,7 +285,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param filename ChucK file to be run
      * @param colonSeparatedArgs arguments to pass to the file
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     runFileWithArgsWithReplacementDac(filename, colonSeparatedArgs, dacName) {
         const callbackID = this.nextDeferID();
@@ -318,7 +317,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename file to be replace last
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceFileWithReplacementDac(filename, dacName) {
         const callbackID = this.nextDeferID();
@@ -334,7 +333,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename file to be replace last running shred
      * @param colonSeparatedArgs arguments to pass in to file
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceFileWithArgs(filename, colonSeparatedArgs) {
         const callbackID = this.nextDeferID();
@@ -352,7 +351,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @param filename file to be replace last running shred
      * @param colonSeparatedArgs arguments to pass in to file
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceFileWithArgsWithReplacementDac(filename, colonSeparatedArgs, dacName) {
         const callbackID = this.nextDeferID();
@@ -465,7 +464,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the value of a global int variable in ChucK.
      * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
      * @param variable Name of int global variable
-     * @returns Promise with int value of the variable
+     * @returns promise with int value of the variable
      */
     getInt(variable) {
         const callbackID = this.nextDeferID();
@@ -486,7 +485,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global float variable in ChucK.
      * @param variable Name of float global variable
-     * @returns Promise with float value of the variable
+     * @returns promise with float value of the variable
      */
     getFloat(variable) {
         const callbackID = this.nextDeferID();
@@ -507,7 +506,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global string variable in ChucK.
      * @param variable Name of string global variable
-     * @returns Promise with string value of the variable
+     * @returns promise with string value of the variable
      */
     getString(variable) {
         const callbackID = this.nextDeferID();
@@ -587,7 +586,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative int arry
      * @param key The key index (string) to get
-     * @returns Promise with int array value
+     * @returns promise with int array value
      */
     getAssociativeIntArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -611,7 +610,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the values of a global float array in ChucK.
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
      * @param variable Name of float array
-     * @returns Promise of float values
+     * @returns promise of float values
      */
     getFloatArray(variable) {
         const callbackID = this.nextDeferID();
@@ -639,7 +638,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
      * @param variable Name of global float array
      * @param index Index of element
-     * @returns Promise of float value at index
+     * @returns promise of float value at index
      */
     getFloatArrayValue(variable, index) {
         const callbackID = this.nextDeferID();
@@ -670,7 +669,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative float array
      * @param key The key index (string) to get
-     * @returns Promise with float array value
+     * @returns promise with float array value
      */
     getAssociativeFloatArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -695,7 +694,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM integer parameter.
      * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
      * @param name Name of VM int parameter to get
-     * @returns Promise with int value
+     * @returns promise with int value
      */
     getParamInt(name) {
         const callbackID = this.nextDeferID();
@@ -716,7 +715,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get an internal ChucK VM float parameter.
      * @param name Name of VM float parameter to get
-     * @returns Promise with float value
+     * @returns promise with float value
      */
     getParamFloat(name) {
         const callbackID = this.nextDeferID();
@@ -738,7 +737,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM string parameter.
      * e.g. "VERSION".
      * @param name Name of VM string parameter to get
-     * @returns Promise with string value
+     * @returns promise with string value
      */
     getParamString(name) {
         const callbackID = this.nextDeferID();

--- a/dist/Chuck.js
+++ b/dist/Chuck.js
@@ -141,7 +141,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * theChuck.loadFile("./myFile.ck");
      * ```
      * @param url path or url to a file to fetch and load file
-     * @returns promise of fetch request
+     * @returns Promise of fetch request
      */
     async loadFile(url) {
         const filename = url.split("/").pop();
@@ -464,7 +464,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the value of a global int variable in ChucK.
      * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
      * @param variable Name of int global variable
-     * @returns promise with int value of the variable
+     * @returns Promise with int value of the variable
      */
     getInt(variable) {
         const callbackID = this.nextDeferID();
@@ -485,7 +485,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global float variable in ChucK.
      * @param variable Name of float global variable
-     * @returns promise with float value of the variable
+     * @returns Promise with float value of the variable
      */
     getFloat(variable) {
         const callbackID = this.nextDeferID();
@@ -506,7 +506,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global string variable in ChucK.
      * @param variable Name of string global variable
-     * @returns promise with string value of the variable
+     * @returns Promise with string value of the variable
      */
     getString(variable) {
         const callbackID = this.nextDeferID();
@@ -586,7 +586,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative int arry
      * @param key The key index (string) to get
-     * @returns promise with int array value
+     * @returns Promise with int array value
      */
     getAssociativeIntArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -610,7 +610,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get the values of a global float array in ChucK.
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
      * @param variable Name of float array
-     * @returns promise of float values
+     * @returns Promise of float values
      */
     getFloatArray(variable) {
         const callbackID = this.nextDeferID();
@@ -638,7 +638,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
      * @param variable Name of global float array
      * @param index Index of element
-     * @returns promise of float value at index
+     * @returns Promise of float value at index
      */
     getFloatArrayValue(variable, index) {
         const callbackID = this.nextDeferID();
@@ -669,7 +669,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative float array
      * @param key The key index (string) to get
-     * @returns promise with float array value
+     * @returns Promise with float array value
      */
     getAssociativeFloatArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -694,7 +694,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM integer parameter.
      * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
      * @param name Name of VM int parameter to get
-     * @returns promise with int value
+     * @returns Promise with int value
      */
     getParamInt(name) {
         const callbackID = this.nextDeferID();
@@ -715,7 +715,7 @@ export default class Chuck extends window.AudioWorkletNode {
     /**
      * Get an internal ChucK VM float parameter.
      * @param name Name of VM float parameter to get
-     * @returns promise with float value
+     * @returns Promise with float value
      */
     getParamFloat(name) {
         const callbackID = this.nextDeferID();
@@ -737,7 +737,7 @@ export default class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM string parameter.
      * e.g. "VERSION".
      * @param name Name of VM string parameter to get
-     * @returns promise with string value
+     * @returns Promise with string value
      */
     getParamString(name) {
         const callbackID = this.nextDeferID();

--- a/src/Chuck.ts
+++ b/src/Chuck.ts
@@ -142,7 +142,7 @@ export default class Chuck extends window.AudioWorkletNode {
 
   /**
    * Private function for ChucK to handle execution of tasks. 
-   * Will create a Deferred Promise that wraps a task for WebChucK to execute
+   * Will create a Deferred promise that wraps a task for WebChucK to execute
    * @returns callbackID to a an action for ChucK to perform
    */
   private nextDeferID(): number {
@@ -174,18 +174,18 @@ export default class Chuck extends window.AudioWorkletNode {
    * theChuck.loadFile("./myFile.ck");
    * ```
    * @param url path or url to a file to fetch and load file
+   * @returns promise of fetch request
    */
-  public async loadFile(url: string) {
-    const filename = url.split("/").pop()!;
-    if (url.endsWith(".ck")) {
-      return fetch(url).then((response) => response.text()).then((text) => {
-        this.createFile("", filename, text)
-      });
-    } else {
-      return fetch(url).then((response) => response.arrayBuffer()).then((buffer) => {
-        this.createFile("", filename, new Uint8Array(buffer));
-      });
-    }
+  public async loadFile(url: string): Promise<void> {
+      const filename = url.split("/").pop()!;
+      return fetch(url)
+          .then((response) => response.arrayBuffer())
+          .then((buffer) => {
+              this.createFile("", filename, new Uint8Array(buffer));
+          })
+          .catch((err) => {
+              throw new Error(err);
+          });
   }
 
   // ================== Run/Replace Code ================== //
@@ -193,12 +193,12 @@ export default class Chuck extends window.AudioWorkletNode {
    * Run a string of ChucK code.
    * @example theChuck.runCode("SinOsc osc => dac; 1::second => now;");
    * @param code ChucK code string to be executed
-   * @returns Promise to the shred ID
+   * @returns Promise to shred ID
    */
-  public runCode(code: string) {
+  public runCode(code: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.RUN_CODE, { callback: callbackID, code });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -207,16 +207,16 @@ export default class Chuck extends window.AudioWorkletNode {
    * -tf (5/30/2023)
    * @param code ChucK code string to be executed
    * @param dacName dac for ChucK (??)
-   * @returns promise to the shred ID
+   * @returns Promise to shred ID
    */
-  public runCodeWithReplacementDac(code: string, dacName: string) {
+  public runCodeWithReplacementDac(code: string, dacName: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.RUN_CODE_WITH_REPLACEMENT_DAC, {
       callback: callbackID,
       code,
       dac_name: dacName,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -225,13 +225,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param code ChucK code string to run and replace last shred
    * @returns Promise to shred ID that is replaced
    */
-  public replaceCode(code: string) {
+  public replaceCode(code: string): Promise<number>{
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REPLACE_CODE, {
       callback: callbackID,
       code,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -239,26 +239,26 @@ export default class Chuck extends window.AudioWorkletNode {
    * Replace last running shred with string of ChucK code to execute, to another dac (??)
    * @param code ChucK code string to replace last Shred
    * @param dacName dac for ChucK (??)
-   * @returns promise to shred ID
+   * @returns Promise to shred ID
    */
-  public replaceCodeWithReplacementDac(code: string, dacName: string) {
+  public replaceCodeWithReplacementDac(code: string, dacName: string): Promise<number>{
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REPLACE_CODE_WITH_REPLACEMENT_DAC, {
       callback: callbackID,
       code,
       dac_name: dacName,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
    * Remove the last running shred from Chuck Virtual Machine.
-   * @returns promise to the shred ID that was removed
+   * @returns Promise to the shred ID that was removed
    */
-  public removeLastCode() {
+  public removeLastCode(): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REMOVE_LAST_CODE, { callback: callbackID });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   // ================== Run/Replace File ================== //
@@ -275,13 +275,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param filename ChucK file to be run
    * @returns Promise to running shred ID
    */
-  public runFile(filename: string) {
+  public runFile(filename: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.RUN_FILE, {
       callback: callbackID,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -290,16 +290,16 @@ export default class Chuck extends window.AudioWorkletNode {
    * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
    * @param filename ChucK file to be run
    * @param dacName dac for ChucK (??)
-   * @returns promise to shred ID
+   * @returns Promise to shred ID
    */
-  public runFileWithReplacementDac(filename: string, dacName: string) {
+  public runFileWithReplacementDac(filename: string, dacName: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.RUN_FILE_WITH_REPLACEMENT_DAC, {
       callback: callbackID,
       dac_name: dacName,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -310,14 +310,14 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param colonSeparatedArgs arguments to pass to the file separated by colons
    * @returns Promise to running shred ID
    */
-  public runFileWithArgs(filename: string, colonSeparatedArgs: string) {
+  public runFileWithArgs(filename: string, colonSeparatedArgs: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.RUN_FILE_WITH_ARGS, {
       callback: callbackID,
       colon_separated_args: colonSeparatedArgs,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -327,13 +327,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param filename ChucK file to be run
    * @param colonSeparatedArgs arguments to pass to the file
    * @param dacName dac for ChucK (??)
-   * @returns promise to shred ID
+   * @returns Promise to shred ID
    */
   public runFileWithArgsWithReplacementDac(
     filename: string,
     colonSeparatedArgs: string,
     dacName: string
-  ) {
+  ): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.RUN_FILE_WITH_ARGS, {
       callback: callbackID,
@@ -341,7 +341,7 @@ export default class Chuck extends window.AudioWorkletNode {
       dac_name: dacName,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -350,13 +350,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param filename file to be replace last 
    * @returns Promise to replaced shred ID
    */
-  public replaceFile(filename: string) {
+  public replaceFile(filename: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REPLACE_FILE, {
       callback: callbackID,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -365,16 +365,16 @@ export default class Chuck extends window.AudioWorkletNode {
    * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
    * @param filename file to be replace last 
    * @param dacName dac for ChucK (??)
-   * @returns promise to shred ID
+   * @returns Promise to shred ID
    */
-  public replaceFileWithReplacementDac(filename: string, dacName: string) {
+  public replaceFileWithReplacementDac(filename: string, dacName: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REPLACE_FILE_WITH_REPLACEMENT_DAC, {
       callback: callbackID,
       dac_name: dacName,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -382,16 +382,16 @@ export default class Chuck extends window.AudioWorkletNode {
    * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
    * @param filename file to be replace last running shred
    * @param colonSeparatedArgs arguments to pass in to file
-   * @returns promise to shred ID
+   * @returns Promise to shred ID
    */
-  public replaceFileWithArgs(filename: string, colonSeparatedArgs: string) {
+  public replaceFileWithArgs(filename: string, colonSeparatedArgs: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REPLACE_FILE_WITH_ARGS, {
       callback: callbackID,
       colon_separated_args: colonSeparatedArgs,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -401,13 +401,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param filename file to be replace last running shred
    * @param colonSeparatedArgs arguments to pass in to file
    * @param dacName dac for ChucK (??)
-   * @returns promise to shred ID
+   * @returns Promise to shred ID
    */
   public replaceFileWithArgsWithReplacementDac(
     filename: string,
     colonSeparatedArgs: string,
     dacName: string
-  ) {
+  ): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REPLACE_FILE_WITH_ARGS, {
       callback: callbackID,
@@ -415,7 +415,7 @@ export default class Chuck extends window.AudioWorkletNode {
       dac_name: dacName,
       filename,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   // ================== Shred =================== //
@@ -424,13 +424,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param shred shred ID to be removed
    * @returns Promise to shred ID if removed successfully, otherwise "removing code failed"
    */
-  public removeShred(shred: number | string) {
+  public removeShred(shred: number | string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.REMOVE_SHRED, {
       shred,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
 
@@ -439,13 +439,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param shred The shred ID to check
    * @returns Promise to whether shred is running, 1 if running, 0 if not
    */
-  public isShredActive(shred: number | string) {
+  public isShredActive(shred: number | string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.IS_SHRED_ACTIVE, {
       shred,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   // ================== Event =================== //
@@ -490,7 +490,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param callback javascript callback function
    * @returns javascript callback ID
    */
-  public startListeningForEvent(variable: string, callback: () => void) {
+  public startListeningForEvent(variable: string, callback: () => void): number {
     const callbackID = this.eventCallbackCounter++;
     this.eventCallbacks[callbackID] = callback;
     this.sendMessage(OutMessage.START_LISTENING_FOR_EVENT, {
@@ -528,15 +528,15 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get the value of a global int variable in ChucK.
    * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
    * @param variable Name of int global variable
-   * @returns Promise with int value of the variable
+   * @returns promise with int value of the variable
    */
-  public getInt(variable: string) {
+  public getInt(variable: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_INT, {
       variable,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -551,15 +551,15 @@ export default class Chuck extends window.AudioWorkletNode {
   /**
    * Get the value of a global float variable in ChucK.
    * @param variable Name of float global variable
-   * @returns Promise with float value of the variable
+   * @returns promise with float value of the variable
    */
-  public getFloat(variable: string) {
+  public getFloat(variable: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_FLOAT, {
       variable,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -574,15 +574,15 @@ export default class Chuck extends window.AudioWorkletNode {
   /**
    * Get the value of a global string variable in ChucK.
    * @param variable Name of string global variable
-   * @returns Promise with string value of the variable
+   * @returns promise with string value of the variable
    */
-  public getString(variable: string) {
+  public getString(variable: string): Promise<string> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_STRING, {
       variable,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<string>;
   }
 
   // ================== Int[] =================== //
@@ -600,13 +600,13 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param variable Name of global int array variable
    * @returns Promise to array of numbers 
    */
-  public getIntArray(variable: string) {
+  public getIntArray(variable: string): Promise<number[]>{
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_INT_ARRAY, {
       variable,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number[]>;
   }
 
 
@@ -630,14 +630,14 @@ export default class Chuck extends window.AudioWorkletNode {
    * @param index Array index to get
    * @returns Promise to the value at the index
    */
-  public getIntArrayValue(variable: string, index: number) {
+  public getIntArrayValue(variable: string, index: number): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_INT_ARRAY_VALUE, {
       variable,
       index,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -665,16 +665,16 @@ export default class Chuck extends window.AudioWorkletNode {
    * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
    * @param variable Name of gobal associative int arry
    * @param key The key index (string) to get 
-   * @returns Promise with int array value
+   * @returns promise with int array value
    */
-  public getAssociativeIntArrayValue(variable: string, key: string) {
+  public getAssociativeIntArrayValue(variable: string, key: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_ASSOCIATIVE_INT_ARRAY_VALUE, {
       variable,
       key,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   // ================== Float[] =================== //
@@ -691,15 +691,15 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get the values of a global float array in ChucK.
    * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
    * @param variable Name of float array
-   * @returns Promise of float values
+   * @returns promise of float values
    */
-  public getFloatArray(variable: string) {
+  public getFloatArray(variable: string): Promise<number[]> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_FLOAT_ARRAY, {
       variable,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number[]>;
   }
 
   /**
@@ -721,16 +721,16 @@ export default class Chuck extends window.AudioWorkletNode {
    * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
    * @param variable Name of global float array
    * @param index Index of element
-   * @returns Promise of float value at index
+   * @returns promise of float value at index
    */
-  public getFloatArrayValue(variable: string, index: number) {
+  public getFloatArrayValue(variable: string, index: number): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_FLOAT_ARRAY_VALUE, {
       variable,
       index,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -758,16 +758,16 @@ export default class Chuck extends window.AudioWorkletNode {
    * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
    * @param variable Name of gobal associative float array
    * @param key The key index (string) to get 
-   * @returns Promise with float array value
+   * @returns promise with float array value
    */
-  public getAssociativeFloatArrayValue(variable: string, key: string) {
+  public getAssociativeFloatArrayValue(variable: string, key: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_ASSOCIATIVE_FLOAT_ARRAY_VALUE, {
       variable,
       key,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
 
@@ -785,15 +785,15 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get an internal ChucK VM integer parameter.
    * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
    * @param name Name of VM int parameter to get 
-   * @returns Promise with int value
+   * @returns promise with int value
    */
-  public getParamInt(name: string) {
+  public getParamInt(name: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_PARAM_INT, {
       name,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -807,15 +807,15 @@ export default class Chuck extends window.AudioWorkletNode {
   /**
    * Get an internal ChucK VM float parameter.
    * @param name Name of VM float parameter to get
-   * @returns Promise with float value
+   * @returns promise with float value
    */
-  public getParamFloat(name: string) {
+  public getParamFloat(name: string): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_PARAM_FLOAT, {
       name,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   /**
@@ -830,15 +830,15 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get an internal ChucK VM string parameter.
    * e.g. "VERSION".
    * @param name Name of VM string parameter to get
-   * @returns Promise with string value
+   * @returns promise with string value
    */
-  public getParamString(name: string) {
+  public getParamString(name: string): Promise<string> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_PARAM_STRING, {
       name,
       callback: callbackID,
     });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<string>;
   }
 
   // ================== ChucK VM =================== //
@@ -846,10 +846,10 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get the current time in samples of the ChucK VM.
    * @returns Promise to current sample time in ChucK (int)
    */
-  public now() {
+  public now(): Promise<number> {
     const callbackID = this.nextDeferID();
     this.sendMessage(OutMessage.GET_CHUCK_NOW, { callback: callbackID });
-    return this.deferredPromises[callbackID].value();
+    return this.deferredPromises[callbackID].value() as Promise<number>;
   }
 
   // ================= Clear ====================== //

--- a/src/Chuck.ts
+++ b/src/Chuck.ts
@@ -174,7 +174,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * theChuck.loadFile("./myFile.ck");
    * ```
    * @param url path or url to a file to fetch and load file
-   * @returns promise of fetch request
+   * @returns Promise of fetch request
    */
   public async loadFile(url: string): Promise<void> {
       const filename = url.split("/").pop()!;
@@ -528,7 +528,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get the value of a global int variable in ChucK.
    * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
    * @param variable Name of int global variable
-   * @returns promise with int value of the variable
+   * @returns Promise with int value of the variable
    */
   public getInt(variable: string): Promise<number> {
     const callbackID = this.nextDeferID();
@@ -551,7 +551,7 @@ export default class Chuck extends window.AudioWorkletNode {
   /**
    * Get the value of a global float variable in ChucK.
    * @param variable Name of float global variable
-   * @returns promise with float value of the variable
+   * @returns Promise with float value of the variable
    */
   public getFloat(variable: string): Promise<number> {
     const callbackID = this.nextDeferID();
@@ -574,7 +574,7 @@ export default class Chuck extends window.AudioWorkletNode {
   /**
    * Get the value of a global string variable in ChucK.
    * @param variable Name of string global variable
-   * @returns promise with string value of the variable
+   * @returns Promise with string value of the variable
    */
   public getString(variable: string): Promise<string> {
     const callbackID = this.nextDeferID();
@@ -665,7 +665,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
    * @param variable Name of gobal associative int arry
    * @param key The key index (string) to get 
-   * @returns promise with int array value
+   * @returns Promise with int array value
    */
   public getAssociativeIntArrayValue(variable: string, key: string): Promise<number> {
     const callbackID = this.nextDeferID();
@@ -691,7 +691,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get the values of a global float array in ChucK.
    * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
    * @param variable Name of float array
-   * @returns promise of float values
+   * @returns Promise of float values
    */
   public getFloatArray(variable: string): Promise<number[]> {
     const callbackID = this.nextDeferID();
@@ -721,7 +721,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
    * @param variable Name of global float array
    * @param index Index of element
-   * @returns promise of float value at index
+   * @returns Promise of float value at index
    */
   public getFloatArrayValue(variable: string, index: number): Promise<number> {
     const callbackID = this.nextDeferID();
@@ -758,7 +758,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
    * @param variable Name of gobal associative float array
    * @param key The key index (string) to get 
-   * @returns promise with float array value
+   * @returns Promise with float array value
    */
   public getAssociativeFloatArrayValue(variable: string, key: string): Promise<number> {
     const callbackID = this.nextDeferID();
@@ -785,7 +785,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get an internal ChucK VM integer parameter.
    * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
    * @param name Name of VM int parameter to get 
-   * @returns promise with int value
+   * @returns Promise with int value
    */
   public getParamInt(name: string): Promise<number> {
     const callbackID = this.nextDeferID();
@@ -807,7 +807,7 @@ export default class Chuck extends window.AudioWorkletNode {
   /**
    * Get an internal ChucK VM float parameter.
    * @param name Name of VM float parameter to get
-   * @returns promise with float value
+   * @returns Promise with float value
    */
   public getParamFloat(name: string): Promise<number> {
     const callbackID = this.nextDeferID();
@@ -830,7 +830,7 @@ export default class Chuck extends window.AudioWorkletNode {
    * Get an internal ChucK VM string parameter.
    * e.g. "VERSION".
    * @param name Name of VM string parameter to get
-   * @returns promise with string value
+   * @returns Promise with string value
    */
   public getParamString(name: string): Promise<string> {
     const callbackID = this.nextDeferID();

--- a/src/DeferredPromise.ts
+++ b/src/DeferredPromise.ts
@@ -40,7 +40,7 @@ export default class DeferredPromise<T = any> {
    * ``` 
    * @returns Promise to value `T`. If resolved, the value is returned. If rejected, the error is thrown.
    */
-  public async value() {
+  public async value(): Promise<T> {
     // whether resolve or reject, return the value wrapped in this.promise
     return await this.promise;
   }

--- a/src/wc-bundle.js
+++ b/src/wc-bundle.js
@@ -268,7 +268,7 @@ class Chuck extends window.AudioWorkletNode {
     }
     /**
      * Private function for ChucK to handle execution of tasks.
-     * Will create a Deferred Promise that wraps a task for WebChucK to execute
+     * Will create a Deferred promise that wraps a task for WebChucK to execute
      * @returns callbackID to a an action for ChucK to perform
      */
     nextDeferID() {
@@ -299,26 +299,25 @@ class Chuck extends window.AudioWorkletNode {
      * theChuck.loadFile("./myFile.ck");
      * ```
      * @param url path or url to a file to fetch and load file
+     * @returns promise of fetch request
      */
     async loadFile(url) {
         const filename = url.split("/").pop();
-        if (url.endsWith(".ck")) {
-            return fetch(url).then((response) => response.text()).then((text) => {
-                this.createFile("", filename, text);
-            });
-        }
-        else {
-            return fetch(url).then((response) => response.arrayBuffer()).then((buffer) => {
-                this.createFile("", filename, new Uint8Array(buffer));
-            });
-        }
+        return fetch(url)
+            .then((response) => response.arrayBuffer())
+            .then((buffer) => {
+            this.createFile("", filename, new Uint8Array(buffer));
+        })
+            .catch((err) => {
+            throw new Error(err);
+        });
     }
     // ================== Run/Replace Code ================== //
     /**
      * Run a string of ChucK code.
      * @example theChuck.runCode("SinOsc osc => dac; 1::second => now;");
      * @param code ChucK code string to be executed
-     * @returns Promise to the shred ID
+     * @returns Promise to shred ID
      */
     runCode(code) {
         const callbackID = this.nextDeferID();
@@ -331,7 +330,7 @@ class Chuck extends window.AudioWorkletNode {
      * -tf (5/30/2023)
      * @param code ChucK code string to be executed
      * @param dacName dac for ChucK (??)
-     * @returns promise to the shred ID
+     * @returns Promise to shred ID
      */
     runCodeWithReplacementDac(code, dacName) {
         const callbackID = this.nextDeferID();
@@ -361,7 +360,7 @@ class Chuck extends window.AudioWorkletNode {
      * Replace last running shred with string of ChucK code to execute, to another dac (??)
      * @param code ChucK code string to replace last Shred
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceCodeWithReplacementDac(code, dacName) {
         const callbackID = this.nextDeferID();
@@ -374,7 +373,7 @@ class Chuck extends window.AudioWorkletNode {
     }
     /**
      * Remove the last running shred from Chuck Virtual Machine.
-     * @returns promise to the shred ID that was removed
+     * @returns Promise to the shred ID that was removed
      */
     removeLastCode() {
         const callbackID = this.nextDeferID();
@@ -409,7 +408,7 @@ class Chuck extends window.AudioWorkletNode {
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename ChucK file to be run
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     runFileWithReplacementDac(filename, dacName) {
         const callbackID = this.nextDeferID();
@@ -444,7 +443,7 @@ class Chuck extends window.AudioWorkletNode {
      * @param filename ChucK file to be run
      * @param colonSeparatedArgs arguments to pass to the file
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     runFileWithArgsWithReplacementDac(filename, colonSeparatedArgs, dacName) {
         const callbackID = this.nextDeferID();
@@ -476,7 +475,7 @@ class Chuck extends window.AudioWorkletNode {
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename file to be replace last
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceFileWithReplacementDac(filename, dacName) {
         const callbackID = this.nextDeferID();
@@ -492,7 +491,7 @@ class Chuck extends window.AudioWorkletNode {
      * Note that the file must already have been loaded via {@link init | filenamesToPreload}, {@link createFile}, or {@link loadFile}
      * @param filename file to be replace last running shred
      * @param colonSeparatedArgs arguments to pass in to file
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceFileWithArgs(filename, colonSeparatedArgs) {
         const callbackID = this.nextDeferID();
@@ -510,7 +509,7 @@ class Chuck extends window.AudioWorkletNode {
      * @param filename file to be replace last running shred
      * @param colonSeparatedArgs arguments to pass in to file
      * @param dacName dac for ChucK (??)
-     * @returns promise to shred ID
+     * @returns Promise to shred ID
      */
     replaceFileWithArgsWithReplacementDac(filename, colonSeparatedArgs, dacName) {
         const callbackID = this.nextDeferID();
@@ -623,7 +622,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get the value of a global int variable in ChucK.
      * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
      * @param variable Name of int global variable
-     * @returns Promise with int value of the variable
+     * @returns promise with int value of the variable
      */
     getInt(variable) {
         const callbackID = this.nextDeferID();
@@ -644,7 +643,7 @@ class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global float variable in ChucK.
      * @param variable Name of float global variable
-     * @returns Promise with float value of the variable
+     * @returns promise with float value of the variable
      */
     getFloat(variable) {
         const callbackID = this.nextDeferID();
@@ -665,7 +664,7 @@ class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global string variable in ChucK.
      * @param variable Name of string global variable
-     * @returns Promise with string value of the variable
+     * @returns promise with string value of the variable
      */
     getString(variable) {
         const callbackID = this.nextDeferID();
@@ -745,7 +744,7 @@ class Chuck extends window.AudioWorkletNode {
      * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative int arry
      * @param key The key index (string) to get
-     * @returns Promise with int array value
+     * @returns promise with int array value
      */
     getAssociativeIntArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -769,7 +768,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get the values of a global float array in ChucK.
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
      * @param variable Name of float array
-     * @returns Promise of float values
+     * @returns promise of float values
      */
     getFloatArray(variable) {
         const callbackID = this.nextDeferID();
@@ -797,7 +796,7 @@ class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
      * @param variable Name of global float array
      * @param index Index of element
-     * @returns Promise of float value at index
+     * @returns promise of float value at index
      */
     getFloatArrayValue(variable, index) {
         const callbackID = this.nextDeferID();
@@ -828,7 +827,7 @@ class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative float array
      * @param key The key index (string) to get
-     * @returns Promise with float array value
+     * @returns promise with float array value
      */
     getAssociativeFloatArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -853,7 +852,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM integer parameter.
      * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
      * @param name Name of VM int parameter to get
-     * @returns Promise with int value
+     * @returns promise with int value
      */
     getParamInt(name) {
         const callbackID = this.nextDeferID();
@@ -874,7 +873,7 @@ class Chuck extends window.AudioWorkletNode {
     /**
      * Get an internal ChucK VM float parameter.
      * @param name Name of VM float parameter to get
-     * @returns Promise with float value
+     * @returns promise with float value
      */
     getParamFloat(name) {
         const callbackID = this.nextDeferID();
@@ -896,7 +895,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM string parameter.
      * e.g. "VERSION".
      * @param name Name of VM string parameter to get
-     * @returns Promise with string value
+     * @returns promise with string value
      */
     getParamString(name) {
         const callbackID = this.nextDeferID();

--- a/src/wc-bundle.js
+++ b/src/wc-bundle.js
@@ -299,7 +299,7 @@ class Chuck extends window.AudioWorkletNode {
      * theChuck.loadFile("./myFile.ck");
      * ```
      * @param url path or url to a file to fetch and load file
-     * @returns promise of fetch request
+     * @returns Promise of fetch request
      */
     async loadFile(url) {
         const filename = url.split("/").pop();
@@ -622,7 +622,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get the value of a global int variable in ChucK.
      * @example const myGlobalInt = await theChuck.getInt("MY_GLOBAL_INT");
      * @param variable Name of int global variable
-     * @returns promise with int value of the variable
+     * @returns Promise with int value of the variable
      */
     getInt(variable) {
         const callbackID = this.nextDeferID();
@@ -643,7 +643,7 @@ class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global float variable in ChucK.
      * @param variable Name of float global variable
-     * @returns promise with float value of the variable
+     * @returns Promise with float value of the variable
      */
     getFloat(variable) {
         const callbackID = this.nextDeferID();
@@ -664,7 +664,7 @@ class Chuck extends window.AudioWorkletNode {
     /**
      * Get the value of a global string variable in ChucK.
      * @param variable Name of string global variable
-     * @returns promise with string value of the variable
+     * @returns Promise with string value of the variable
      */
     getString(variable) {
         const callbackID = this.nextDeferID();
@@ -744,7 +744,7 @@ class Chuck extends window.AudioWorkletNode {
      * e.g. theChucK.getAssociateIntArrayValue("MY_INT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative int arry
      * @param key The key index (string) to get
-     * @returns promise with int array value
+     * @returns Promise with int array value
      */
     getAssociativeIntArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -768,7 +768,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get the values of a global float array in ChucK.
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY");
      * @param variable Name of float array
-     * @returns promise of float values
+     * @returns Promise of float values
      */
     getFloatArray(variable) {
         const callbackID = this.nextDeferID();
@@ -796,7 +796,7 @@ class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getFloatArray("MY_FLOAT_ARRAY", 1);
      * @param variable Name of global float array
      * @param index Index of element
-     * @returns promise of float value at index
+     * @returns Promise of float value at index
      */
     getFloatArrayValue(variable, index) {
         const callbackID = this.nextDeferID();
@@ -827,7 +827,7 @@ class Chuck extends window.AudioWorkletNode {
      * @example theChucK.getAssociateFloatArrayValue("MY_FLOAT_ASSOCIATIVE_ARRAY", "key");
      * @param variable Name of gobal associative float array
      * @param key The key index (string) to get
-     * @returns promise with float array value
+     * @returns Promise with float array value
      */
     getAssociativeFloatArrayValue(variable, key) {
         const callbackID = this.nextDeferID();
@@ -852,7 +852,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM integer parameter.
      * e.g. "SAMPLE_RATE", "INPUT_CHANNELS", "OUTPUT_CHANNELS", "BUFFER_SIZE", "IS_REAL_TIME_AUDIO_HINT".
      * @param name Name of VM int parameter to get
-     * @returns promise with int value
+     * @returns Promise with int value
      */
     getParamInt(name) {
         const callbackID = this.nextDeferID();
@@ -873,7 +873,7 @@ class Chuck extends window.AudioWorkletNode {
     /**
      * Get an internal ChucK VM float parameter.
      * @param name Name of VM float parameter to get
-     * @returns promise with float value
+     * @returns Promise with float value
      */
     getParamFloat(name) {
         const callbackID = this.nextDeferID();
@@ -895,7 +895,7 @@ class Chuck extends window.AudioWorkletNode {
      * Get an internal ChucK VM string parameter.
      * e.g. "VERSION".
      * @param name Name of VM string parameter to get
-     * @returns promise with string value
+     * @returns Promise with string value
      */
     getParamString(name) {
         const callbackID = this.nextDeferID();

--- a/test/chuckTest.js
+++ b/test/chuckTest.js
@@ -80,6 +80,7 @@ import('../src/wc-bundle.js').then(async (module) => {
 // DEFINE ALL TESTS!!!
 const testSuite = [
 
+    /*
     new Test(1, "[sound] Define a ChucK and runCode 220hz 0.5 second", async () => {
         var aChuck = await Chuck.init([], undefined, undefined, "../src/");
         var outputBox = document.getElementById("output-" + 1);
@@ -262,6 +263,40 @@ const testSuite = [
             test3 = active == 0
         });
         return test1 && test2 && test3;
+    }),
+    */
+
+    new Test(10, "Chuck get Promise<type> returns", async () => {
+        var aChuck = await Chuck.init([], undefined, undefined, "../src/");
+        var outputBox = document.getElementById("output-" + 10);
+
+        // print lambda
+        print = (output) => {
+            outputBox.innerHTML += output + "<br>";
+        }
+        aChuck.chuckPrint = print;
+
+        aChuck.runCode(`2::second => now;`);
+        aChuck.runCode(`2::second => now;`);
+        let test = true;
+        await new Promise(resolve => setTimeout(resolve, 50));
+        aChuck.isShredActive(1).then((active) => {
+            print("isShredActive(1) returns: " + active);
+            test &= active == 1;
+        });
+        aChuck.removeShred(1).then((removed) => {
+            print("removeShred(1) returns: " + removed);
+            test &= removed == 1;
+        });
+        aChuck.removeShred(-1).then((removed) => {
+            print("removeShred(-1) returns: " + removed);
+            test &= removed == 0;
+        }).catch((err) => {
+            print("removeShred(-1) throws: " + err);
+            test &= err === "Remove code failed"
+        });
+
+        return test;
     }),
 
 

--- a/test/chuckTest.js
+++ b/test/chuckTest.js
@@ -80,7 +80,6 @@ import('../src/wc-bundle.js').then(async (module) => {
 // DEFINE ALL TESTS!!!
 const testSuite = [
 
-    /*
     new Test(1, "[sound] Define a ChucK and runCode 220hz 0.5 second", async () => {
         var aChuck = await Chuck.init([], undefined, undefined, "../src/");
         var outputBox = document.getElementById("output-" + 1);
@@ -264,7 +263,6 @@ const testSuite = [
         });
         return test1 && test2 && test3;
     }),
-    */
 
     new Test(10, "Chuck get Promise<type> returns", async () => {
         var aChuck = await Chuck.init([], undefined, undefined, "../src/");


### PR DESCRIPTION
Returns for getInt, getString, .etc functions are now typed properly (`Promise<number>`, `Promise<string>`) instead of just `Promise<unknown>`